### PR TITLE
getDrugOffer server cb in cornerselling

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,5 @@
 name: Lint
-on: [push, pull_request_target, workflow_dispatch]
+on: [push, pull_request_target]
 jobs:
   lint:
     name: Lint Resource

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,5 @@
 name: Lint
-on: [push, pull_request_target]
+on: [push, pull_request_target, workflow_dispatch]
 jobs:
   lint:
     name: Lint Resource

--- a/client/cornerselling.lua
+++ b/client/cornerselling.lua
@@ -290,7 +290,7 @@ end
 -- Events
 RegisterNetEvent('qb-drugs:client:cornerselling', function()
     if CurrentCops >= config.minimumDrugSalePolice then
-        local hasDrugs = lib.callback.await('qb-drugs:server:getDrugOffer', false) ~= nil and true or false
+        local hasDrugs = not not lib.callback.await('qb-drugs:server:getDrugOffer', false)
         if hasDrugs then
             toggleSelling()
         else

--- a/client/cornerselling.lua
+++ b/client/cornerselling.lua
@@ -4,7 +4,6 @@ local hasTarget = false
 local lastPed = {}
 local stealingPed = nil
 local stealData = {}
-local availableDrugs = {}
 local currentOfferDrug = nil
 local CurrentCops = 0
 local textDrawn = false
@@ -14,13 +13,7 @@ local function tooFarAway()
     exports.qbx_core:Notify(locale('error.too_far_away'), 'error')
     cornerselling = false
     hasTarget = false
-    availableDrugs = {}
-end
-
-local function alertPolice()
-    if config.policeCallChance <= math.random(1, 100) then
-        TriggerServerEvent('police:server:policeAlert', 'Drug sale in progress')
-    end
+    currentOfferDrug = nil
 end
 
 local function robberyPed()
@@ -76,6 +69,7 @@ local function robberyPed()
                             lib.showTextUI(locale('info.pick_up_button'))
                         end
                         if IsControlJustReleased(0, 38) then
+                            lib.hideTextUI()
                             textDrawn = false
                             lib.requestAnimDict('pickup_object')
                             TaskPlayAnim(cache.ped, 'pickup_object', 'pickup_low', 8.0, -8.0, -1, 1, 0, false, false, false)
@@ -115,19 +109,15 @@ local function sellToPed(ped)
     end
 
     local successChance = math.random(1, 100)
-    local scamChance = math.random(1, 100)
     local getRobbed = math.random(1, 100)
     if successChance <= config.successChance then hasTarget = false return end
 
-    local drugType = math.random(1, #availableDrugs)
-    local bagAmount = math.random(1, availableDrugs[drugType].amount)
-    if bagAmount > 15 then bagAmount = math.random(9, 15) end
+    currentOfferDrug = lib.callback.await('qb-drugs:server:getDrugOffer', false)
 
-    currentOfferDrug = availableDrugs[drugType]
-
-    local ddata = config.drugsPrice[currentOfferDrug.item]
-    local randomPrice = math.random(ddata.min, ddata.max) * bagAmount
-    if scamChance <= config.scamChance then randomPrice = math.random(3, 10) * bagAmount end
+    if currentOfferDrug == nil then
+        exports.qbx_core:Notify(locale('error.no_drugs_left'), 'error')
+        return
+    end
 
     SetEntityAsNoLongerNeeded(ped)
     ClearPedTasks(ped)
@@ -155,13 +145,13 @@ local function sellToPed(ped)
             local pedCoords2 = GetEntityCoords(ped)
             local pedDist2 = #(coords2 - pedCoords2)
             if getRobbed <= config.robberyChance then
-                TriggerServerEvent('qb-drugs:server:robCornerDrugs', drugType, bagAmount)
-                exports.qbx_core:Notify(locale('info.has_been_robbed', bagAmount, availableDrugs[drugType].label))
+                TriggerServerEvent('qb-drugs:server:robCornerDrugs', currentOfferDrug.idx, currentOfferDrug.amount)
+                exports.qbx_core:Notify(locale('info.has_been_robbed', currentOfferDrug.amount, currentOfferDrug.chosen.label))
                 stealingPed = ped
                 stealData = {
-                    item = availableDrugs[drugType].item,
-                    drugType = drugType,
-                    amount = bagAmount,
+                    item = currentOfferDrug.chosen.item,
+                    drugType = currentOfferDrug.idx,
+                    amount = currentOfferDrug.amount,
                 }
                 hasTarget = false
                 local moveTo = GetEntityCoords(cache.ped)
@@ -179,9 +169,10 @@ local function sellToPed(ped)
                             {
                                 name = 'selldrugs',
                                 icon = 'fas fa-hand-holding-dollar',
-                                label = locale('info.target_drug_offer', bagAmount, currentOfferDrug.label, randomPrice),
+                                label = locale('info.target_drug_offer', currentOfferDrug.amount, currentOfferDrug.chosen.label, currentOfferDrug.total),
                                 onSelect = function()
-                                    TriggerServerEvent('qb-drugs:server:sellCornerDrugs', drugType, bagAmount, randomPrice)
+                                    TriggerServerEvent('qb-drugs:server:sellCornerDrugs', currentOfferDrug.idx, currentOfferDrug.amount, currentOfferDrug.total)
+                                    currentOfferDrug = nil
                                     hasTarget = false
                                     lib.requestAnimDict('gestures@f@standing@casual', 5000)
                                     TaskPlayAnim(cache.ped, 'gestures@f@standing@casual', 'gesture_point', 3.0, 3.0, -1, 49, 0, false, false, false)
@@ -192,7 +183,6 @@ local function sellToPed(ped)
                                     ClearPedTasksImmediately(ped)
                                     lastPed[#lastPed + 1] = ped
                                     exports.ox_target:removeEntity(targetPedSale, optionNamesTargetPed)
-                                    alertPolice()
                                 end,
                             },
                             {
@@ -200,6 +190,7 @@ local function sellToPed(ped)
                                 icon = 'fas fa-x',
                                 label = locale('info.decline_offer'),
                                 onSelect = function()
+                                    currentOfferDrug = nil
                                     exports.qbx_core:Notify(locale('error.offer_declined'), 'error')
                                     hasTarget = false
                                     SetPedKeepTask(ped, false)
@@ -214,12 +205,12 @@ local function sellToPed(ped)
                     elseif not config.useTarget then
                         if not textDrawn then
                             textDrawn = true
-                            lib.showTextUI(locale('info.drug_offer', bagAmount, currentOfferDrug.label, randomPrice))
+                            lib.showTextUI(locale('info.drug_offer', currentOfferDrug.amount, currentOfferDrug.chosen.label, currentOfferDrug.total))
                         end
                         if IsControlJustPressed(0, 38) then
                             lib.hideTextUI()
                             textDrawn = false
-                            TriggerServerEvent('qb-drugs:server:sellCornerDrugs', drugType, bagAmount, randomPrice)
+                            TriggerServerEvent('qb-drugs:server:sellCornerDrugs', currentOfferDrug.idx, currentOfferDrug.amount, currentOfferDrug.total)
                             hasTarget = false
                             lib.requestAnimDict('gestures@f@standing@casual', 5000)
                             TaskPlayAnim(cache.ped, 'gestures@f@standing@casual', 'gesture_point', 3.0, 3.0, -1, 49, 0, false, false, false)
@@ -299,9 +290,8 @@ end
 -- Events
 RegisterNetEvent('qb-drugs:client:cornerselling', function()
     if CurrentCops >= config.minimumDrugSalePolice then
-        local result = lib.callback.await('qb-drugs:server:getAvailableDrugs', false)
-        if result then
-            availableDrugs = result
+        local hasDrugs = lib.callback.await('qb-drugs:server:getDrugOffer', false) ~= nil and true or false
+        if hasDrugs then
             toggleSelling()
         else
             exports.qbx_core:Notify(locale('error.has_no_drugs'), 'error')
@@ -318,12 +308,4 @@ end)
 
 RegisterNetEvent('police:SetCopCount', function(amount)
     CurrentCops = amount
-end)
-
-RegisterNetEvent('qb-drugs:client:refreshAvailableDrugs', function(items)
-    availableDrugs = items
-    if availableDrugs == nil or #availableDrugs <= 0 then
-        exports.qbx_core:Notify(locale('error.no_drugs_left'), 'error')
-        cornerselling = false
-    end
 end)

--- a/client/deliveries.lua
+++ b/client/deliveries.lua
@@ -158,17 +158,11 @@ local function deliveryTimer()
     end)
 end
 
-local function alertPolice()
-    if config.policeCallChance <= math.random(1, 100) then
-        TriggerServerEvent('police:server:policeAlert', 'Suspicous activity')
-    end
-end
-
 local function deliverStuff()
     if deliveryTimeout > 0 then
         Wait(500)
         TriggerEvent('animations:client:EmoteCommandStart', {'bumbin'})
-        alertPolice()
+        TriggerServerEvent('qb-drugs:server:randomPoliceAlert')
         if lib.progressCircle({
             label = locale('info.delivering_products'),
             duration = 3500,

--- a/config/client.lua
+++ b/config/client.lua
@@ -1,48 +1,8 @@
 return {
     useTarget = GetConvar('UseTarget', 'false') == 'true',
-    policeCallChance = 15,
     successChance = 50,
-    scamChance = 25,
     robberyChance = 25,
     minimumDrugSalePolice = 0,
-    drugsPrice = {
-        ['weed_white-widow'] = {
-            min = 15,
-            max = 24,
-        },
-        ['weed_og-kush'] = {
-            min = 15,
-            max = 28,
-        },
-        ['weed_skunk'] = {
-            min = 15,
-            max = 31,
-        },
-        ['weed_amnesia'] = {
-            min = 18,
-            max = 34,
-        },
-        ['weed_purple-haze'] = {
-            min = 18,
-            max = 37,
-        },
-        ['weed_ak47'] = {
-            min = 18,
-            max = 40,
-        },
-        ['crack_baggy'] = {
-            min = 18,
-            max = 34,
-        },
-        ['cokebaggy'] = {
-            min = 18,
-            max = 37,
-        },
-        ['meth'] = {
-            min = 18,
-            max = 40,
-        },
-    },
     deliveryLocations = {
         {
             label = 'Strip Club',

--- a/config/server.lua
+++ b/config/server.lua
@@ -102,6 +102,46 @@ return {
         'cokebaggy',
         'meth'
     },
+    cornerSellingDrugsPrice = {
+        ['weed_white-widow'] = {
+            min = 15,
+            max = 24,
+        },
+        ['weed_og-kush'] = {
+            min = 15,
+            max = 28,
+        },
+        ['weed_skunk'] = {
+            min = 15,
+            max = 31,
+        },
+        ['weed_amnesia'] = {
+            min = 18,
+            max = 34,
+        },
+        ['weed_purple-haze'] = {
+            min = 18,
+            max = 37,
+        },
+        ['weed_ak47'] = {
+            min = 18,
+            max = 40,
+        },
+        ['crack_baggy'] = {
+            min = 18,
+            max = 34,
+        },
+        ['cokebaggy'] = {
+            min = 18,
+            max = 37,
+        },
+        ['meth'] = {
+            min = 18,
+            max = 40,
+        },
+    },
+    scamChance = 25,
+    policeCallChance = 15,
     useMarkedBills = false,
     deliveryRepGain = 1,
     deliveryRepLoss = 1,

--- a/server/cornerselling.lua
+++ b/server/cornerselling.lua
@@ -58,7 +58,7 @@ RegisterNetEvent('qb-drugs:server:sellCornerDrugs', function(drugType, amount, p
         exports.ox_inventory:RemoveItem(player.PlayerData.source, item, amount)
         player.Functions.AddMoney('cash', price, 'sold-cornerdrugs')
         if config.policeCallChance >= math.random(1, 100) then
-            TriggerEvent('police:server:policeAlert', locale('info.possible_drug_dealing'))
+            TriggerEvent('police:server:policeAlert', locale('info.possible_drug_dealing'), nil, player.PlayerData.source)
         end
     else
         TriggerClientEvent('qb-drugs:client:cornerselling', player.PlayerData.source)
@@ -74,5 +74,4 @@ RegisterNetEvent('qb-drugs:server:robCornerDrugs', function(drugType, amount)
     local item = availableDrugs[drugType].item
 
     exports.ox_inventory:RemoveItem(player.PlayerData.source, item, amount)
-    TriggerClientEvent('qb-drugs:client:refreshAvailableDrugs', player.PlayerData.source, getAvailableDrugs(player.PlayerData.source))
 end)

--- a/server/cornerselling.lua
+++ b/server/cornerselling.lua
@@ -20,8 +20,19 @@ local function getAvailableDrugs(source)
     return table.type(availableDrugs) ~= 'empty' and availableDrugs or nil
 end
 
-lib.callback.register('qb-drugs:server:getAvailableDrugs', function(source)
-    return getAvailableDrugs(source)
+lib.callback.register('qb-drugs:server:getDrugOffer', function(source)
+    local player = exports.qbx_core:GetPlayer(source)
+    if not player then return nil end
+    local availableDrugs = getAvailableDrugs(player.PlayerData.source)
+    if availableDrugs == nil then return nil end
+
+    local randomDrug = math.random(1, #availableDrugs)
+    local chosenDrug = availableDrugs[randomDrug]
+    local offeredAmount = math.random(1, chosenDrug.amount > 15 and 15 or chosenDrug.amount)
+    local basePrice = math.random(config.cornerSellingDrugsPrice[chosenDrug.item].min, config.cornerSellingDrugsPrice[chosenDrug.item].max)
+    local totalPrice = config.scamChance >= math.random(1, 100) and basePrice * offeredAmount or math.random(3, 10) * offeredAmount
+
+    return { chosen = chosenDrug, idx = randomDrug, amount = offeredAmount, total = totalPrice }
 end)
 
 RegisterNetEvent('qb-drugs:server:giveStealItems', function(drugType, amount)
@@ -34,9 +45,8 @@ RegisterNetEvent('qb-drugs:server:giveStealItems', function(drugType, amount)
 end)
 
 RegisterNetEvent('qb-drugs:server:sellCornerDrugs', function(drugType, amount, price)
-    local src = source
-    local player = exports.qbx_core:GetPlayer(src)
-    local availableDrugs = getAvailableDrugs(src)
+    local player = exports.qbx_core:GetPlayer(source)
+    local availableDrugs = getAvailableDrugs(player.PlayerData.source)
 
     if not availableDrugs or not player then return end
 
@@ -44,24 +54,25 @@ RegisterNetEvent('qb-drugs:server:sellCornerDrugs', function(drugType, amount, p
 
     local hasItem = player.Functions.GetItemByName(item)
     if hasItem.amount >= amount then
-        exports.qbx_core:Notify(src, locale('success.offer_accepted'), 'success')
-        exports.ox_inventory:RemoveItem(src, item, amount)
+        exports.qbx_core:Notify(player.PlayerData.source, locale('success.offer_accepted'), 'success')
+        exports.ox_inventory:RemoveItem(player.PlayerData.source, item, amount)
         player.Functions.AddMoney('cash', price, 'sold-cornerdrugs')
-        TriggerClientEvent('qb-drugs:client:refreshAvailableDrugs', src, getAvailableDrugs(src))
+        if config.policeCallChance >= math.random(1, 100) then
+            TriggerEvent('police:server:policeAlert', locale('info.possible_drug_dealing'))
+        end
     else
-        TriggerClientEvent('qb-drugs:client:cornerselling', src)
+        TriggerClientEvent('qb-drugs:client:cornerselling', player.PlayerData.source)
     end
 end)
 
 RegisterNetEvent('qb-drugs:server:robCornerDrugs', function(drugType, amount)
-    local src = source
-    local player = exports.qbx_core:GetPlayer(src)
-    local availableDrugs = getAvailableDrugs(src)
+    local player = exports.qbx_core:GetPlayer(source)
+    local availableDrugs = getAvailableDrugs(player.PlayerData.source)
 
     if not availableDrugs or not player then return end
 
     local item = availableDrugs[drugType].item
 
-    exports.ox_inventory:RemoveItem(src, item, amount)
-    TriggerClientEvent('qb-drugs:client:refreshAvailableDrugs', src, getAvailableDrugs(src))
+    exports.ox_inventory:RemoveItem(player.PlayerData.source, item, amount)
+    TriggerClientEvent('qb-drugs:client:refreshAvailableDrugs', player.PlayerData.source, getAvailableDrugs(player.PlayerData.source))
 end)

--- a/server/deliveries.lua
+++ b/server/deliveries.lua
@@ -9,6 +9,17 @@ lib.callback.register('qb-drugs:server:RequestConfig', function()
     return sharedConfig.dealers
 end)
 
+RegisterNetEvent('qb-drugs:server:randomPoliceAlert', function()
+    local src = source
+    local player = exports.qbx_core:GetPlayer(src)
+
+    if not player then return end
+
+    if config.policeCallChance >= math.random(1, 100) then
+        TriggerEvent('police:server:policeAlert', locale('info.possible_drug_dealing'), nil, player.PlayerData.source)
+    end
+end)
+
 RegisterNetEvent('qb-drugs:server:updateDealerItems', function(itemData, amount, dealer)
     local src = source
     local player = exports.qbx_core:GetPlayer(src)

--- a/server/deliveries.lua
+++ b/server/deliveries.lua
@@ -10,11 +10,8 @@ lib.callback.register('qb-drugs:server:RequestConfig', function()
 end)
 
 RegisterNetEvent('qb-drugs:server:randomPoliceAlert', function()
-    local src = source
-    local player = exports.qbx_core:GetPlayer(src)
-
+    local player = exports.qbx_core:GetPlayer(source)
     if not player then return end
-
     if config.policeCallChance >= math.random(1, 100) then
         TriggerEvent('police:server:policeAlert', locale('info.possible_drug_dealing'), nil, player.PlayerData.source)
     end


### PR DESCRIPTION
## Description

- **client:** remove availableDrugs table, remove refreshAvailableDrugs event, hide text UI after taking back from robbing ped
- **server:** remove getAvailableDrugs cb, add getDrugOffer server callback, add police alerting


_(squash commits, was trying to manually trigger linting workflow)_

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
