### PR TITLE
fixed giveStealItems not giving item

### DIFF
--- a/server/cornerselling.lua
+++ b/server/cornerselling.lua
@@ -41,7 +41,7 @@ RegisterNetEvent('qb-drugs:server:giveStealItems', function(drugType, amount)
 
     if not availableDrugs or not player then return end
 
-    exports.ox_inventory:AddItem(source, availableDrugs[drugType].item, amount)
+    exports.ox_inventory:AddItem(player.PlayerData.source, availableDrugs[drugType].item, amount)
 end)
 
 RegisterNetEvent('qb-drugs:server:sellCornerDrugs', function(drugType, amount, price)


### PR DESCRIPTION
fixed giveStealItems not giving item

## Description
changes source to player.PlayerData.source

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
