### PR TITLE
fix: secure drug reward events

### DIFF
--- a/client/cornerselling.lua
+++ b/client/cornerselling.lua
@@ -28,7 +28,7 @@ local function robberyPed()
                     lib.playAnim(cache.ped, 'pickup_object', 'pickup_low', 8.0, -8.0, -1, 1, 0, false, false, false)
                     Wait(2000)
                     ClearPedTasks(cache.ped)
-                    TriggerServerEvent('qb-drugs:server:giveStealItems', stealData.drugType, stealData.amount)
+                    TriggerServerEvent('qb-drugs:server:giveStealItems')
                     TriggerEvent('inventory:client:ItemBox', exports.ox_inventory:Items()[stealData.item], 'add')
                     stealingPed = nil
                     stealData = {}
@@ -73,7 +73,7 @@ local function robberyPed()
                             lib.playAnim(cache.ped, 'pickup_object', 'pickup_low', 8.0, -8.0, -1, 1, 0, false, false, false)
                             Wait(2000)
                             ClearPedTasks(cache.ped)
-                            TriggerServerEvent('qb-drugs:server:giveStealItems', stealData.drugType, stealData.amount)
+                            TriggerServerEvent('qb-drugs:server:giveStealItems')
                             TriggerEvent('inventory:client:ItemBox', exports.ox_inventory:Items()[stealData.item], 'add')
                             stealingPed = nil
                             stealData = {}
@@ -143,7 +143,7 @@ local function sellToPed(ped)
             local pedCoords2 = GetEntityCoords(ped)
             local pedDist2 = #(coords2 - pedCoords2)
             if getRobbed <= config.robberyChance then
-                TriggerServerEvent('qb-drugs:server:robCornerDrugs', currentOfferDrug.idx, currentOfferDrug.amount)
+                TriggerServerEvent('qb-drugs:server:robCornerDrugs')
                 exports.qbx_core:Notify(locale('info.has_been_robbed', currentOfferDrug.amount, currentOfferDrug.chosen.label))
                 stealingPed = ped
                 stealData = {
@@ -169,7 +169,7 @@ local function sellToPed(ped)
                                 icon = 'fas fa-hand-holding-dollar',
                                 label = locale('info.target_drug_offer', currentOfferDrug.amount, currentOfferDrug.chosen.label, currentOfferDrug.total),
                                 onSelect = function()
-                                    TriggerServerEvent('qb-drugs:server:sellCornerDrugs', currentOfferDrug.idx, currentOfferDrug.amount, currentOfferDrug.total)
+                                    TriggerServerEvent('qb-drugs:server:sellCornerDrugs')
                                     currentOfferDrug = nil
                                     hasTarget = false
                                     lib.playAnim(cache.ped, 'gestures@f@standing@casual', 'gesture_point', 3.0, 3.0, -1, 49, 0, false, false, false)
@@ -207,7 +207,7 @@ local function sellToPed(ped)
                         if IsControlJustPressed(0, 38) then
                             lib.hideTextUI()
                             textDrawn = false
-                            TriggerServerEvent('qb-drugs:server:sellCornerDrugs', currentOfferDrug.idx, currentOfferDrug.amount, currentOfferDrug.total)
+                            TriggerServerEvent('qb-drugs:server:sellCornerDrugs')
                             hasTarget = false
                             lib.playAnim(cache.ped, 'gestures@f@standing@casual', 'gesture_point', 3.0, 3.0, -1, 49, 0, false, false, false)
                             Wait(650)

--- a/client/deliveries.lua
+++ b/client/deliveries.lua
@@ -116,7 +116,7 @@ local function requestDelivery()
             TriggerServerEvent('qb-phone:server:sendNewMail', {
                 sender = sharedConfig.dealers[currentDealer].name,
                 subject = 'Delivery Location',
-                message = locale('info.delivery_info_email', amount, exports.ox_inventory:Items()[waitingDelivery.itemData.item].label),
+                message = locale('info.delivery_info_email', waitingDelivery.amount, exports.ox_inventory:Items()[waitingDelivery.itemData.item].label),
                 button = {
                     enabled = true,
                     buttonEvent = 'qb-drugs:client:setLocation',

--- a/client/deliveries.lua
+++ b/client/deliveries.lua
@@ -21,6 +21,7 @@ end)
 
 local function getClosestDealer()
     local pCoords = GetEntityCoords(cache.ped)
+    currentDealer = nil
     for k, v in pairs(sharedConfig.dealers) do
         local dealerCoords = vector3(v.coords.x, v.coords.y, v.coords.z)
         if #(pCoords - dealerCoords) < 2 then
@@ -100,35 +101,17 @@ local function knockDealerDoor()
     end
 end
 
-local function randomDeliveryItemOnRep()
-    local myRep = QBX.PlayerData.metadata.dealerrep
-    local availableItems = {}
-    for k in pairs(sharedConfig.deliveryItems) do
-        if sharedConfig.deliveryItems[k].minrep <= myRep then
-            availableItems[#availableItems+1] = k
-        end
-    end
-    return availableItems[math.random(1, #availableItems)]
-end
-
 local function requestDelivery()
     if not waitingDelivery then
         getClosestDealer()
-        local location = math.random(1, #config.deliveryLocations)
-        local amount = math.random(1, 3)
-        local item = randomDeliveryItemOnRep()
+        if not currentDealer then return end
 
-        waitingDelivery = {
-            coords = config.deliveryLocations[location].coords,
-            locationLabel = config.deliveryLocations[location].label,
-            amount = amount,
-            dealer = currentDealer,
-            itemData = sharedConfig.deliveryItems[item],
-            item = item
-        }
+        waitingDelivery = lib.callback.await('qb-drugs:server:requestDelivery', false, currentDealer)
+        if not waitingDelivery then
+            return exports.qbx_core:Notify(locale('error.pending_delivery'), 'error')
+        end
 
         exports.qbx_core:Notify(locale('info.sending_delivery_email'), 'success')
-        TriggerServerEvent('qb-drugs:server:giveDeliveryItems', waitingDelivery)
         SetTimeout(2000, function()
             TriggerServerEvent('qb-phone:server:sendNewMail', {
                 sender = sharedConfig.dealers[currentDealer].name,
@@ -169,7 +152,7 @@ local function deliverStuff()
             canCancel = true,
             disable = { car = true, move = true, combat = true }
         }) then
-            TriggerServerEvent('qb-drugs:server:successDelivery', activeDelivery, true)
+            TriggerServerEvent('qb-drugs:server:successDelivery')
             activeDelivery = nil
             if config.useTarget then
                 exports.ox_target:removeZone('drugDeliveryZone')
@@ -180,7 +163,7 @@ local function deliverStuff()
             ClearPedTasks(cache.ped)
         end
     else
-        TriggerServerEvent('qb-drugs:server:successDelivery', activeDelivery, false)
+        TriggerServerEvent('qb-drugs:server:successDelivery')
     end
     deliveryTimeout = 0
 end

--- a/config/client.lua
+++ b/config/client.lua
@@ -3,26 +3,4 @@ return {
     successChance = 50,
     robberyChance = 25,
     minimumDrugSalePolice = 0,
-    deliveryLocations = {
-        {
-            label = 'Strip Club',
-            coords = vec3(106.24, -1280.32, 29.24),
-        },
-        {
-            label = 'Vinewood Video',
-            coords = vec3(223.98, 121.53, 102.76),
-        },
-        {
-            label = 'Taxi',
-            coords = vec3(882.67, -160.26, 77.11),
-        },
-        {
-            label = 'Resort',
-            coords = vec3(-1245.63, 376.21, 75.34),
-        },
-        {
-            label = 'Bahama Mamas',
-            coords = vec3(-1383.1, -639.99, 28.67),
-        },
-    }
 }

--- a/config/shared.lua
+++ b/config/shared.lua
@@ -11,5 +11,12 @@ return {
             minrep = 0,
             payout = 1000
         },
-    }
+    },
+    deliveryLocations = {
+        {label = 'Strip Club', coords = vec3(106.24, -1280.32, 29.24)},
+        {label = 'Vinewood Video', coords = vec3(223.98, 121.53, 102.76)},
+        {label = 'Taxi', coords = vec3(882.67, -160.26, 77.11)},
+        {label = 'Resort', coords = vec3(-1245.63, 376.21, 75.34)},
+        {label = 'Bahama Mamas', coords = vec3(-1383.1, -639.99, 28.67)},
+    },
 }

--- a/server/cornerselling.lua
+++ b/server/cornerselling.lua
@@ -1,4 +1,7 @@
 local config = require 'config.server'
+local cornerOffers = {}
+local stolenItems = {}
+local cornerLocks = {}
 
 local function getAvailableDrugs(source)
     local availableDrugs = {}
@@ -32,46 +35,70 @@ lib.callback.register('qb-drugs:server:getDrugOffer', function(source)
     local basePrice = math.random(config.cornerSellingDrugsPrice[chosenDrug.item].min, config.cornerSellingDrugsPrice[chosenDrug.item].max)
     local totalPrice = config.scamChance >= math.random(1, 100) and basePrice * offeredAmount or math.random(3, 10) * offeredAmount
 
+    cornerOffers[source] = {
+        item = chosenDrug.item,
+        amount = offeredAmount,
+        total = totalPrice,
+        expiresAt = os.time() + 60,
+    }
+
     return { chosen = chosenDrug, idx = randomDrug, amount = offeredAmount, total = totalPrice }
 end)
 
-RegisterNetEvent('qb-drugs:server:giveStealItems', function(drugType, amount)
-    local availableDrugs = getAvailableDrugs(source)
-    local player = exports.qbx_core:GetPlayer(source)
+RegisterNetEvent('qb-drugs:server:giveStealItems', function()
+    local src = source
+    local stolen = stolenItems[src]
+    stolenItems[src] = nil
+    if not stolen or stolen.expiresAt < os.time() then return end
 
-    if not availableDrugs or not player then return end
-
-    exports.ox_inventory:AddItem(player.PlayerData.source, availableDrugs[drugType].item, amount)
+    exports.ox_inventory:AddItem(src, stolen.item, stolen.amount)
 end)
 
-RegisterNetEvent('qb-drugs:server:sellCornerDrugs', function(drugType, amount, price)
-    local player = exports.qbx_core:GetPlayer(source)
-    local availableDrugs = getAvailableDrugs(player.PlayerData.source)
+RegisterNetEvent('qb-drugs:server:sellCornerDrugs', function()
+    local src = source
+    if cornerLocks[src] then return end
+    cornerLocks[src] = true
 
-    if not availableDrugs or not player then return end
-
-    local item = availableDrugs[drugType].item
-
-    local hasItem = player.Functions.GetItemByName(item)
-    if hasItem.amount >= amount then
-        exports.qbx_core:Notify(player.PlayerData.source, locale('success.offer_accepted'), 'success')
-        exports.ox_inventory:RemoveItem(player.PlayerData.source, item, amount)
-        player.Functions.AddMoney('cash', price, 'sold-cornerdrugs')
+    local player = exports.qbx_core:GetPlayer(src)
+    local offer = cornerOffers[src]
+    cornerOffers[src] = nil
+    if player and offer and offer.expiresAt >= os.time()
+        and exports.ox_inventory:GetItemCount(src, offer.item) >= offer.amount
+        and exports.ox_inventory:RemoveItem(src, offer.item, offer.amount) then
+        exports.qbx_core:Notify(src, locale('success.offer_accepted'), 'success')
+        player.Functions.AddMoney('cash', offer.total, 'sold-cornerdrugs')
         if config.policeCallChance >= math.random(1, 100) then
-            TriggerEvent('police:server:policeAlert', locale('info.possible_drug_dealing'), nil, player.PlayerData.source)
+            TriggerEvent('police:server:policeAlert', locale('info.possible_drug_dealing'), nil, src)
         end
-    else
-        TriggerClientEvent('qb-drugs:client:cornerselling', player.PlayerData.source)
+    elseif player then
+        TriggerClientEvent('qb-drugs:client:cornerselling', src)
     end
+
+    cornerLocks[src] = nil
 end)
 
-RegisterNetEvent('qb-drugs:server:robCornerDrugs', function(drugType, amount)
-    local player = exports.qbx_core:GetPlayer(source)
-    local availableDrugs = getAvailableDrugs(player.PlayerData.source)
+RegisterNetEvent('qb-drugs:server:robCornerDrugs', function()
+    local src = source
+    if cornerLocks[src] then return end
+    cornerLocks[src] = true
 
-    if not availableDrugs or not player then return end
+    local player = exports.qbx_core:GetPlayer(src)
+    local offer = cornerOffers[src]
+    cornerOffers[src] = nil
+    if player and offer and offer.expiresAt >= os.time()
+        and exports.ox_inventory:RemoveItem(src, offer.item, offer.amount) then
+        stolenItems[src] = {
+            item = offer.item,
+            amount = offer.amount,
+            expiresAt = os.time() + 600,
+        }
+    end
 
-    local item = availableDrugs[drugType].item
+    cornerLocks[src] = nil
+end)
 
-    exports.ox_inventory:RemoveItem(player.PlayerData.source, item, amount)
+AddEventHandler('playerDropped', function()
+    cornerOffers[source] = nil
+    stolenItems[source] = nil
+    cornerLocks[source] = nil
 end)

--- a/server/deliveries.lua
+++ b/server/deliveries.lua
@@ -1,5 +1,26 @@
 local config = require 'config.server'
 local sharedConfig = require 'config.shared'
+local activeDeliveries = {}
+local policeAlertCooldowns = {}
+
+---@param source number
+---@param coords vector3
+---@param maxDistance number
+---@return boolean
+local function isPlayerNear(source, coords, maxDistance)
+    local ped = GetPlayerPed(source)
+    if ped == 0 then return false end
+
+    return #(GetEntityCoords(ped) - coords) <= maxDistance
+end
+
+---@param source number
+---@param dealer string
+---@return boolean
+local function isNearDealer(source, dealer)
+    local dealerData = type(dealer) == 'string' and sharedConfig.dealers[dealer]
+    return dealerData ~= nil and isPlayerNear(source, dealerData.coords, 4.0)
+end
 
 exports('GetDealers', function()
     return sharedConfig.dealers
@@ -10,8 +31,15 @@ lib.callback.register('qb-drugs:server:RequestConfig', function()
 end)
 
 RegisterNetEvent('qb-drugs:server:randomPoliceAlert', function()
-    local player = exports.qbx_core:GetPlayer(source)
-    if not player then return end
+    local src = source
+    local player = exports.qbx_core:GetPlayer(src)
+    local delivery = activeDeliveries[src]
+    if not player or not delivery or not isPlayerNear(src, delivery.data.coords, 5.0) then return end
+
+    local currentTime = GetGameTimer()
+    if policeAlertCooldowns[src] and currentTime - policeAlertCooldowns[src] < 30000 then return end
+    policeAlertCooldowns[src] = currentTime
+
     if config.policeCallChance >= math.random(1, 100) then
         TriggerEvent('police:server:policeAlert', locale('info.possible_drug_dealing'), nil, player.PlayerData.source)
     end
@@ -20,117 +48,141 @@ end)
 RegisterNetEvent('qb-drugs:server:updateDealerItems', function(itemData, amount, dealer)
     local src = source
     local player = exports.qbx_core:GetPlayer(src)
+    if not player or type(itemData) ~= 'table' or type(itemData.slot) ~= 'number'
+        or itemData.slot % 1 ~= 0 or type(amount) ~= 'number' or amount % 1 ~= 0
+        or amount < 1 or amount > 100 or not isNearDealer(src, dealer) then return end
 
-    if not player then return end
-
-    if sharedConfig.dealers[dealer].products[itemData.slot].amount - 1 >= 0 then
-        sharedConfig.dealers[dealer].products[itemData.slot].amount -= amount
-        TriggerClientEvent('qb-drugs:client:setDealerItems', -1, itemData, amount, dealer)
-    else
-        exports.ox_inventory:RemoveItem(src, itemData.name, amount)
-        player.Functions.AddMoney('cash', amount * sharedConfig.dealers[dealer].products[itemData.slot].price)
-        exports.qbx_core:Notify(src, locale('error.item_unavailable'), 'error')
+    local dealerData = sharedConfig.dealers[dealer]
+    local product = dealerData.products[itemData.slot]
+    if not product or itemData.name ~= product.name or player.PlayerData.metadata.dealerrep < product.minrep
+        or product.amount < amount then
+        return exports.qbx_core:Notify(src, locale('error.item_unavailable'), 'error')
     end
+
+    product.amount = product.amount - amount
+    TriggerClientEvent('qb-drugs:client:setDealerItems', -1, {name = product.name, slot = itemData.slot}, amount, dealer)
 end)
 
-RegisterNetEvent('qb-drugs:server:giveDeliveryItems', function(deliveryData)
-    local src = source
-    local player = exports.qbx_core:GetPlayer(src)
+lib.callback.register('qb-drugs:server:requestDelivery', function(source, dealer)
+    local player = exports.qbx_core:GetPlayer(source)
+    if not player or not isNearDealer(source, dealer) then return false end
+    if activeDeliveries[source] then return activeDeliveries[source].data end
 
-    if not player then return end
-
-    local item = sharedConfig.deliveryItems[deliveryData.item].item
-
-    if not item then return end
-
-    exports.ox_inventory:AddItem(src, item, deliveryData.amount)
-end)
-
-RegisterNetEvent('qb-drugs:server:successDelivery', function(deliveryData, inTime)
-    local src = source
-    local player = exports.qbx_core:GetPlayer(src)
-
-    if not player then return end
-
-    local item = sharedConfig.deliveryItems[deliveryData.item].item
-    local itemAmount = deliveryData.amount
-    local payout = deliveryData.itemData.payout * itemAmount
-    local copsOnline = exports.qbx_core:GetDutyCountType('leo')
-    local curRep = player.PlayerData.metadata.dealerrep
-    local invItem = exports.ox_inventory:Search(src, 'count', item)
-    if inTime then
-        if invItem and invItem.amount >= itemAmount then -- on time correct amount
-            exports.ox_inventory:RemoveItem(src, item, itemAmount)
-            if copsOnline > 0 then
-                local copModifier = copsOnline * config.policeDeliveryModifier
-                if config.useMarkedBills then
-                    local worth = math.floor(payout * copModifier)
-                    local metadata = { worth = worth, description = 'Value: ' .. worth }
-                    exports.ox_inventory:AddItem(src, 'markedbills', 1, metadata)
-                else
-                    player.Functions.AddMoney('cash', math.floor(payout * copModifier), 'drug-delivery')
-                end
-            else
-                if config.useMarkedBills then
-                    local metadata = { worth = payout, description = 'Value: ' .. payout }
-                    exports.ox_inventory:AddItem(src, 'markedbills', 1, metadata)
-                else
-                    player.Functions.AddMoney('cash', payout, 'drug-delivery')
-                end
-            end
-            exports.qbx_core:Notify(src, locale('success.order_delivered'), 'success')
-            SetTimeout(math.random(5000, 10000), function()
-                TriggerClientEvent('qb-drugs:client:sendDeliveryMail', src, 'perfect', deliveryData)
-                player.Functions.SetMetaData('dealerrep', (curRep + config.deliveryRepGain))
-            end)
-        else
-            exports.qbx_core:Notify(src, locale('error.order_not_right'), 'error')-- on time incorrect amount
-            if invItem then
-                local newItemAmount = invItem.amount
-                local modifiedPayout = deliveryData.itemData.payout * newItemAmount
-                exports.ox_inventory:RemoveItem(src, item, newItemAmount)
-                player.Functions.AddMoney('cash', math.floor(modifiedPayout / config.wrongAmountFee))
-            end
-            SetTimeout(math.random(5000, 10000), function()
-                TriggerClientEvent('qb-drugs:client:sendDeliveryMail', src, 'bad', deliveryData)
-                if curRep - 1 > 0 then
-                    player.Functions.SetMetaData('dealerrep', (curRep - config.deliveryRepLoss))
-                else
-                    player.Functions.SetMetaData('dealerrep', 0)
-                end
-            end)
+    local stored = player.PlayerData.metadata.drugdelivery
+    if type(stored) == 'table' then
+        local storedItem = sharedConfig.deliveryItems[stored.item]
+        local storedLocation = sharedConfig.deliveryLocations[stored.location]
+        if storedItem and storedLocation and type(stored.amount) == 'number'
+            and stored.amount % 1 == 0 and stored.amount >= 1 and stored.amount <= 3
+            and type(stored.dealer) == 'string' and sharedConfig.dealers[stored.dealer]
+            and type(stored.startedAt) == 'number' then
+            local delivery = {
+                coords = storedLocation.coords,
+                locationLabel = storedLocation.label,
+                amount = stored.amount,
+                dealer = stored.dealer,
+                itemData = storedItem,
+                item = stored.item,
+            }
+            activeDeliveries[source] = {data = delivery, startedAt = stored.startedAt}
+            return delivery
         end
-    else
-        if invItem and invItem.amount >= itemAmount then -- late correct amount
-            exports.qbx_core:Notify(src, locale('error.too_late'), 'error')
-            exports.ox_inventory:RemoveItem(src, item, itemAmount)
-            player.Functions.AddMoney('cash', math.floor(payout / config.overdueDeliveryFee), 'delivery-drugs-too-late')
-            SetTimeout(math.random(5000, 10000), function()
-                TriggerClientEvent('qb-drugs:client:sendDeliveryMail', src, 'late', deliveryData)
-                if curRep - 1 > 0 then
-                    player.Functions.SetMetaData('dealerrep', (curRep - config.deliveryRepLoss))
-                else
-                    player.Functions.SetMetaData('dealerrep', 0)
-                end
-            end)
-        else
-            if invItem then -- late incorrect amount
-                local newItemAmount = invItem.amount
-                local modifiedPayout = deliveryData.itemData.payout * newItemAmount
-                exports.qbx_core:Notify(src, locale('error.too_late'), 'error')
-                exports.ox_inventory:RemoveItem(src, item, itemAmount)
-                player.Functions.AddMoney('cash', math.floor(modifiedPayout / config.overdueDeliveryFee), 'delivery-drugs-too-late')
-                SetTimeout(math.random(5000, 10000), function()
-                    TriggerClientEvent('qb-drugs:client:sendDeliveryMail', src, 'late', deliveryData)
-                    if curRep - 1 > 0 then
-                        player.Functions.SetMetaData('dealerrep', (curRep - config.deliveryRepLoss))
-                    else
-                        player.Functions.SetMetaData('dealerrep', 0)
-                    end
-                end)
-            end
+
+        player.Functions.SetMetaData('drugdelivery', nil)
+    end
+
+    local availableItems = {}
+    for i = 1, #sharedConfig.deliveryItems do
+        if sharedConfig.deliveryItems[i].minrep <= player.PlayerData.metadata.dealerrep then
+            availableItems[#availableItems + 1] = i
         end
     end
+    if #availableItems == 0 then return false end
+
+    local itemIndex = availableItems[math.random(1, #availableItems)]
+    local itemData = sharedConfig.deliveryItems[itemIndex]
+    local locationIndex = math.random(1, #sharedConfig.deliveryLocations)
+    local location = sharedConfig.deliveryLocations[locationIndex]
+    local amount = math.random(1, 3)
+    local delivery = {
+        coords = location.coords,
+        locationLabel = location.label,
+        amount = amount,
+        dealer = dealer,
+        itemData = itemData,
+        item = itemIndex,
+    }
+
+    if not exports.ox_inventory:AddItem(source, itemData.item, amount) then return false end
+
+    activeDeliveries[source] = {
+        data = delivery,
+        startedAt = os.time(),
+    }
+    player.Functions.SetMetaData('drugdelivery', {
+        item = itemIndex,
+        location = locationIndex,
+        amount = amount,
+        dealer = dealer,
+        startedAt = activeDeliveries[source].startedAt,
+    })
+    return delivery
+end)
+
+RegisterNetEvent('qb-drugs:server:successDelivery', function()
+    local src = source
+    local player = exports.qbx_core:GetPlayer(src)
+    local delivery = activeDeliveries[src]
+    if not player or not delivery or not isPlayerNear(src, delivery.data.coords, 4.0) then return end
+
+    activeDeliveries[src] = nil
+    player.Functions.SetMetaData('drugdelivery', nil)
+    local itemData = sharedConfig.deliveryItems[delivery.data.item]
+    if not itemData or itemData.item ~= delivery.data.itemData.item then return end
+
+    local expectedAmount = delivery.data.amount
+    local inventoryAmount = exports.ox_inventory:GetItemCount(src, itemData.item)
+    local deliveredAmount = math.min(expectedAmount, inventoryAmount)
+    local onTime = os.time() - delivery.startedAt <= 300
+    local complete = deliveredAmount == expectedAmount
+    if deliveredAmount < 1 or not exports.ox_inventory:RemoveItem(src, itemData.item, deliveredAmount) then
+        exports.qbx_core:Notify(src, locale('error.order_not_right'), 'error')
+        return
+    end
+
+    local payout = itemData.payout * deliveredAmount
+    if onTime and complete then
+        local copsOnline = exports.qbx_core:GetDutyCountType('leo')
+        if copsOnline > 0 then payout = payout * copsOnline * config.policeDeliveryModifier end
+    elseif onTime then
+        payout = payout / config.wrongAmountFee
+    else
+        payout = payout / config.overdueDeliveryFee
+    end
+    payout = math.floor(payout)
+
+    if config.useMarkedBills then
+        exports.ox_inventory:AddItem(src, 'markedbills', 1, {
+            worth = payout,
+            description = 'Value: ' .. payout,
+        })
+    else
+        player.Functions.AddMoney('cash', payout, onTime and 'drug-delivery' or 'delivery-drugs-too-late')
+    end
+
+    local currentRep = player.PlayerData.metadata.dealerrep
+    local mailType
+    if onTime and complete then
+        mailType = 'perfect'
+        player.Functions.SetMetaData('dealerrep', currentRep + config.deliveryRepGain)
+        exports.qbx_core:Notify(src, locale('success.order_delivered'), 'success')
+    else
+        mailType = onTime and 'bad' or 'late'
+        player.Functions.SetMetaData('dealerrep', math.max(0, currentRep - config.deliveryRepLoss))
+        exports.qbx_core:Notify(src, onTime and locale('error.order_not_right') or locale('error.too_late'), 'error')
+    end
+
+    TriggerClientEvent('qb-drugs:client:sendDeliveryMail', src, mailType, delivery.data)
 end)
 
 
@@ -264,4 +316,9 @@ CreateThread(function()
         end
     end
     TriggerClientEvent('qb-drugs:client:RefreshDealers', -1, sharedConfig.dealers)
+end)
+
+AddEventHandler('playerDropped', function()
+    activeDeliveries[source] = nil
+    policeAlertCooldowns[source] = nil
 end)


### PR DESCRIPTION
## Summary
- make delivery items, locations, timing, payouts, and reputation server-authoritative
- persist active delivery assignments across reconnects to prevent item duplication
- bind corner sales and robberies to short-lived server-generated offers
- make stolen-item recovery one-time and server-authoritative
- validate dealer stock updates, inventory removal, proximity, and alert rate limits

## Validation
- `git diff --check`
- direct Lua control-flow review
- GitHub Lua lint checks will be monitored and fixed